### PR TITLE
Updated AuditingRun logic

### DIFF
--- a/Powershell/O365_Best_Practices.ps1
+++ b/Powershell/O365_Best_Practices.ps1
@@ -56,7 +56,8 @@ if($LitigationHoldRun -eq $true)
 
 if($AuditingRun -eq $true)
 {
-    $Auditing = $AllMailboxes | Where-Object {$_.AuditEnabled -eq $false -or ($_.AuditAdmin.count) -ne 11 -or ($_.AuditDelegate.count) -ne 9 -or ($_.AuditOwner.count) -ne 7 -or $_.AuditLogAgeLimit -lt "364"} 
+    #Only works for E3 licenses due to changing counts for other audit capabilities.
+    $Auditing = $AllMailboxes | Where-Object {($_.PersistedCapabilities -eq "BPOS_S_Enterprise") -and ($_.AuditEnabled -eq $false -or ($_.AuditAdmin.count) -ne 11 -or ($_.AuditDelegate.count) -ne 9 -or ($_.AuditOwner.count) -ne 7 -or $_.AuditLogAgeLimit -lt "364")} 
 
     If(($Auditing.UserPrincipalName).count -eq 0)
     {
@@ -65,7 +66,7 @@ if($AuditingRun -eq $true)
     else
     {
         Write-Host "There are" ($Auditing.UserPrincipalName).count "mailboxes with Auditing not set correctly" -ForegroundColor Red
-        Foreach($Auditmailbox in $LitigationHold)
+        Foreach($Auditmailbox in $Auditing)
             {
             $Auditmailbox.UserPrincipalName | Set-Mailbox -AuditEnabled $true -AuditOwner Create,HardDelete,MailboxLogin,Move,MoveToDeletedItems,SoftDelete,Update -AuditDelegate Create,FolderBind,HardDelete,Move,MoveToDeletedItems,SendAs,SendOnBehalf,SoftDelete,Update –AuditAdmin Copy,Create,FolderBind,HardDelete,MessageBind,Move,MoveToDeletedItems,SendAs,SendOnBehalf,SoftDelete,Update -AuditLogAgeLimit 365
             }


### PR DESCRIPTION
Incorrect variable being looped. New line #69. Also updated logic search for the audit query.

Just an FYI that the comparison being done here is only good for E3 licensed accounts (tested on F1, E1, and E3). Based on some quick troubleshooting in my environment, the #Count for AuditAdmin, AuditDelegate, and AuditOwner will vary based on license type. We utilize E1 and F1 which caused this to freak out. I would suggest adding a filter for ($_.PersistedCapabilities -eq "BPOS_S_Enterprise") to explicitly only look at E3 for which the query is valid.

This is my first pull request so please be gentle.

Thanks,
Steve